### PR TITLE
fix misplaced input element in chrome

### DIFF
--- a/src/collective/upload/static/css/jquery.fileupload-ui.css
+++ b/src/collective/upload/static/css/jquery.fileupload-ui.css
@@ -31,6 +31,7 @@
 .fileupload-buttonbar .btn,
 .fileupload-buttonbar .toggle {
   margin-bottom: 5px;
+  position: relative;
 }
 .files .progress {
   width: 200px;


### PR DESCRIPTION
In chrome (tested with chrome 27) the file input element is not at the right place (at the add button) therefore the file dialog does not open if the add button is clicked.
This changeset fixes this.
