### PR TITLE
Use "application/javascript" media type instead of the obsolete "text/javascript"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 1.0rc2 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- Use "application/javascript" media type instead of the obsolete "text/javascript".
+  [hvelarde]
+
 - Depend on collective.js.bootstrap (closes `#31`_).
   [rodfersou]
 

--- a/src/collective/upload/browser.py
+++ b/src/collective/upload/browser.py
@@ -212,7 +212,7 @@ class JSVariables(grok.View):
 
     def render(self):
         response = self.request.response
-        response.setHeader('content-type', 'text/javascript;;charset=utf-8')
+        response.setHeader('content-type', 'application/javascript')
 
         messageTemplate = 'jupload={{}};jupload.messages = {{\n{0}}};\njupload.config = {1};\n'
         template = ''


### PR DESCRIPTION
See: http://www.rfc-editor.org/rfc/rfc4329.txt