### PR TITLE
Fix IE conditional comment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 1.0rc2 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- Fix IE conditional comment on JS registry
+  [tcurvelo]
+
 - Drop support for Plone 4.2 (we no longer test under this version but it may work).
   [hvelarde]
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -42,8 +42,6 @@ recipe = collective.recipe.omelette
 eggs = ${instance:eggs}
 
 [versions]
-plone.recipe.codeanalysis = 2.0
-# use latest version of coverage
+# use latest version of coverage and setuptools
 coverage =
-# use latest version of setuptools
 setuptools =

--- a/src/collective/upload/profiles/default/jsregistry.xml
+++ b/src/collective/upload/profiles/default/jsregistry.xml
@@ -66,5 +66,5 @@
   <!-- The XDomainRequest Transport is included for cross-domain file deletion for IE8+ -->
   <javascript id="++resource++collective.upload/cors/jquery.xdr-transport.js"
       cacheable="True" compression="none" cookable="True" enabled="True"
-      expression="" inline="False" authenticated="True" conditionalcomment="if gte IE 8" />
+      expression="" inline="False" authenticated="True" conditionalcomment="gte IE 8" />
 </object>

--- a/src/collective/upload/profiles/default/metadata.xml
+++ b/src/collective/upload/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2</version>
+  <version>3</version>
 </metadata>

--- a/src/collective/upload/upgrades/configure.zcml
+++ b/src/collective/upload/upgrades/configure.zcml
@@ -1,3 +1,4 @@
 <configure xmlns="http://namespaces.zope.org/zope">
   <include package=".v2" />
+  <include package=".v3" />
 </configure>

--- a/src/collective/upload/upgrades/v3/__init__.py
+++ b/src/collective/upload/upgrades/v3/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from collective.upload.config import PROJECTNAME
+from collective.upload.logger import logger
+
+
+def update_jsregistry(setup_tool):
+    """Update jsregistry"""
+    profile = 'profile-{0}:default'.format(PROJECTNAME)
+    setup_tool.runImportStepFromProfile(profile, 'jsregistry')
+    logger.info('JS registry updated.')

--- a/src/collective/upload/upgrades/v3/configure.zcml
+++ b/src/collective/upload/upgrades/v3/configure.zcml
@@ -1,0 +1,20 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="collective.upload">
+
+  <genericsetup:upgradeSteps
+      source="2"
+      destination="3"
+      profile="collective.upload:default">
+
+    <genericsetup:upgradeStep
+        title="Update jsregistry"
+        description=""
+        handler=".update_jsregistry"
+        />
+
+  </genericsetup:upgradeSteps>
+
+</configure>


### PR DESCRIPTION
In `portal_javascripts`/`jsregistry.xml` conditional comments, we must not use the `if` token. Just the condition itself.
 
    <!--[if Condition]>...<![endif]-->

Otherwise, IE will show up the expression on the top.

![if gte ie](https://cloud.githubusercontent.com/assets/308793/12682767/0ac610be-c694-11e5-97f8-a4945f5d6d1d.jpg)


