### PR TITLE
Fix uninstall tests

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -43,5 +43,7 @@ eggs = ${instance:eggs}
 
 [versions]
 plone.recipe.codeanalysis = 2.0
+# use latest version of coverage
+coverage =
 # use latest version of setuptools
 setuptools =

--- a/src/collective/upload/profiles/uninstall/jsregistry.xml
+++ b/src/collective/upload/profiles/uninstall/jsregistry.xml
@@ -12,3 +12,4 @@
   <javascript remove="True" id="++resource++collective.upload/vendor/bootstrap.min.js"/>
   <javascript remove="True" id="++resource++collective.upload/main.js"/>
   <javascript remove="True" id="++resource++collective.upload/cors/jquery.xdr-transport.js"/>
+</object>


### PR DESCRIPTION
A missing close tag in jsregistry.xml was breaking the tests.
